### PR TITLE
add setup docs to run RAI text and image DPv2 components

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,88 @@ Responsible AI dashboard for image data|Assess and understand your NLP models, c
 
 ## ⚙️ Setup
 
-In this section you will learn how to set-up and configure an AzureML Managed Spark cluster in your AzureML workspace. 
+In this section you will learn how to run one AzureML pipeline to register a model and another pipeline to create an RAI dashboard for text and image data.
+
+In your azureml workspace, please create an AMLCompute CPU cluster called "cpucluster". This cluster will be used to run the CPU jobs submitted.
+
+To run the DPv2 components, please first run az login:
+
+```
+az login
+```
+
+Then, we can setup an environment:
+
+```
+conda create -y -n dpv2 python=3.8
+conda activate dpv2
+```
+
+We can install the azure-cli and azure-ai-ml packages to submit jobs to AzureML workspaces:
+
+```
+pip install azure-cli
+pip install azure-ai-ml
+```
 
 
+The az extension will need to be installed using:
+
+```
+az extension add --source https://azuremlsdktestpypi.blob.core.windows.net/wheels/sdk-cli-v2/ml-latest-py3-none-any.whl --yes
+```
+
+The extension can then be updated using:
+
+```
+az extension update -n ml
+```
+
+You can also check the az extension version using:
+
+```
+az version
+```
+
+You will need to set the subscription id where you will be submitting the job to:
+
+```
+az account set -s $SubId
+```
+
+Navigate to the CLI directory in the examples folder:
+
+```
+cd examples\CLI
+```
+
+# Running DPv2 Text Components
+
+To submit the yaml jobs, please run the training yaml first to create the model:
+
+```
+az ml job create --file test_text_pipeline_train.yaml --workspace <YOUR_WORKSPACE> --resource-group <YOUR_RESOURCE_GROUP>
+```
+
+Then you can run the RAI pipeline to create the dashboard:
+
+```
+az ml job create --file test_text_pipeline_rai.yaml --workspace <YOUR_WORKSPACE> --resource-group <YOUR_RESOURCE_GROUP>
+```
+
+# Running DPv2 Vision Components
+
+To submit the yaml jobs, please run the training yaml first to create the model:
+
+```
+az ml job create --file test_vision_pipeline_train.yaml --workspace <YOUR_WORKSPACE> --resource-group <YOUR_RESOURCE_GROUP>
+```
+
+Then you can run the RAI pipeline to create the dashboard:
+
+```
+az ml job create --file test_vision_pipeline_rai.yaml --workspace <YOUR_WORKSPACE> --resource-group <YOUR_RESOURCE_GROUP>
+```
 
 ## 🎓 Learn
 

--- a/examples/CLI/test_text_pipeline_rai.yaml
+++ b/examples/CLI/test_text_pipeline_rai.yaml
@@ -1,0 +1,39 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: AML_RAI_Text_Sample_1
+type: pipeline
+
+compute: azureml:cpucluster
+
+inputs:
+  registered_model_name: hf_model
+  hf_model_info: hf_model_1:1
+
+settings:
+  default_datastore: azureml:workspaceblobstore
+  default_compute: azureml:cpucluster
+  continue_on_step_failure: false
+
+jobs:
+  fetch_data_job:
+    type: command
+    component: azureml:fetch_text_data:1
+
+  analyse_model:
+    type: command
+    component: azureml:rai_text_insights:1
+    inputs:
+      task_type: text_classification
+      model_input:
+        type: mlflow_model
+        path: azureml:hf_model_1:1
+      model_info: ${{parent.inputs.hf_model_info}}
+      train_dataset:
+        type: mltable
+        path: ${{parent.jobs.fetch_data_job.outputs.train_data}}
+      test_dataset:
+        type: mltable
+        path: ${{parent.jobs.fetch_data_job.outputs.test_data}}
+      target_column_name: emotion
+      maximum_rows_for_test_dataset: 5000
+      classes: '[]'
+      enable_explanation: True

--- a/examples/CLI/test_text_pipeline_train.yaml
+++ b/examples/CLI/test_text_pipeline_train.yaml
@@ -1,0 +1,23 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: AML_RAI_Text_Sample_1
+type: pipeline
+
+compute: azureml:cpucluster
+
+inputs:
+  registered_model_name: hf_model
+  model_suffix: 1
+
+settings:
+  default_datastore: azureml:workspaceblobstore
+  default_compute: azureml:cpucluster
+  continue_on_step_failure: false
+
+jobs:
+  train_model_job:
+    type: command
+    component: azureml:hf_train:1
+    inputs:
+      model_base_name: ${{parent.inputs.registered_model_name}}
+      model_name_suffix: ${{parent.inputs.model_suffix}}
+      device: -1

--- a/examples/CLI/test_vision_pipeline_rai.yaml
+++ b/examples/CLI/test_vision_pipeline_rai.yaml
@@ -1,0 +1,42 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: AML_RAI_Vision_Sample_2
+type: pipeline
+
+compute: azureml:cpucluster
+
+identity:
+  type: user_identity
+
+inputs:
+  registered_model_name: vision_model
+  vision_model_info: vision_model_1:1
+
+settings:
+  default_datastore: azureml:workspaceblobstore
+  default_compute: azureml:cpucluster
+  continue_on_step_failure: false
+
+jobs:
+  fetch_data_job:
+    type: command
+    component: azureml:fetch_image_url_data:1
+
+  analyse_model:
+    type: command
+    component: azureml:rai_vision_insights:1
+    inputs:
+      task_type: image_classification
+      model_input:
+        type: mlflow_model
+        path: azureml:vision_model_1:1
+      model_info: ${{parent.inputs.vision_model_info}}
+      train_dataset:
+        type: mltable
+        path: ${{parent.jobs.fetch_data_job.outputs.train_data}}
+      test_dataset:
+        type: mltable
+        path: ${{parent.jobs.fetch_data_job.outputs.test_data}}
+      target_column_name: label
+      maximum_rows_for_test_dataset: 5000
+      classes: '[]'
+      model_type: fastai

--- a/examples/CLI/test_vision_pipeline_train.yaml
+++ b/examples/CLI/test_vision_pipeline_train.yaml
@@ -1,0 +1,23 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: AML_RAI_Vision_Sample_2
+type: pipeline
+
+compute: azureml:cpucluster
+
+inputs:
+  registered_model_name: vision_model
+  model_suffix: 1
+
+settings:
+  default_datastore: azureml:workspaceblobstore
+  default_compute: azureml:cpucluster
+  continue_on_step_failure: false
+
+jobs:
+  train_model_job:
+    type: command
+    component: azureml:fetch_image_model:1
+    inputs:
+      model_base_name: ${{parent.inputs.registered_model_name}}
+      model_name_suffix: ${{parent.inputs.model_suffix}}
+      device: -1


### PR DESCRIPTION
Add setup docs to:
1.) Setup environment for submitting DPv2 jobs
2.) Add yaml files
3.) Instructions to submit yaml jobs to create a.) text and b.) image registered models and then submit yaml jobs to create the RAI dashboard for text and RAI dashboard for image data.